### PR TITLE
ci: remove workflow args

### DIFF
--- a/.github/workflows/validate_code.yml
+++ b/.github/workflows/validate_code.yml
@@ -2,10 +2,6 @@ name: validate generic code
 
 on:
   workflow_call:
-    secrets:
-      GITHUB_TOKEN:
-        description: The GITHUB_TOKEN
-        required: true
 
 jobs:
   validate-code:


### PR DESCRIPTION
# Pull Request Form

**What does this PR do and why we need it**:

Removed the GITHUB_TOKEN arg which breaks the workflow, this will cause the linter to throw an error!

**Is your branch up to date with main?**:

> No? Unsure? -> execute command `git pull --rebase origin main`

[ ] Branch is up to date with main at time of PR

**What type of PR is this?**

> Select only one `commit category` enter 'X'

**Commit Category**

> [ ] bug fix
> [ ] feature
> [ ] refactor
> [ ] testing
> [ ] document
> [X] workflow

**Please ensure there is an issue for the change, if not create one of the apropriate type**:

> Format: `https://github.com/rusty-apps/<REPOSITORY>/issues/<ISSUE_NUMBER>`

Fixes Issue: [<https://github.com/rusty-apps/workflows/issues/1>]

**Have you updated the necessary documentation?**

- [ ] Documentation update is required by this PR.
- [ ] Documentation has been updated.

**The changes have been linted**
[X] This causes an error in the linter 

**The code has been tested**

- [ ] Additional tests added for this code change.
- [ ] Code has been tested and all tests passed.

**How to test changes / Special notes to the reviewer**:
Run a workflow using the re-usable validate-code workflow